### PR TITLE
setting SACI clock to 1MHz per ASIC design team request

### DIFF
--- a/firmware/common/ePixHr10kT/rtl/Application.vhd
+++ b/firmware/common/ePixHr10kT/rtl/Application.vhd
@@ -789,7 +789,7 @@ begin
    generic map (
       AXIL_CLK_PERIOD_G  => 10.0E-9, -- In units of seconds
       AXIL_TIMEOUT_G     => 1.0E-3,  -- In units of seconds
-      SACI_CLK_PERIOD_G  => 0.25E-6, -- In units of seconds
+      SACI_CLK_PERIOD_G  => 1.00E-6, -- In units of seconds
       SACI_CLK_FREERUN_G => false,
       SACI_RSP_BUSSED_G  => true,
       SACI_NUM_CHIPS_G   => NUMBER_OF_ASICS_C)


### PR DESCRIPTION
Matt W. tests with reduce SACI clock speed has gotten good result with apparently no SACI register access errors.