### PR TITLE
Timing trigger test

### DIFF
--- a/firmware/common/ePixHr10kTLclsIITiming/rtl/Application.vhd
+++ b/firmware/common/ePixHr10kTLclsIITiming/rtl/Application.vhd
@@ -510,6 +510,7 @@ begin
       pgpTrigger        when boardConfig.epixhrDbgSel1 = "10110" else
       acqStart          when boardConfig.epixhrDbgSel1 = "10111" else
       dataSendStreched  when boardConfig.epixhrDbgSel1 = "11000" else
+      timingRunTrigger  when boardConfig.epixhrDbgSel1 = "11001" else
       '0';   
 
    connMps    <= not connMpsMux;        -- required because the board has a
@@ -540,6 +541,7 @@ begin
       pgpTrigger        when boardConfig.epixhrDbgSel1 = "10110" else
       acqStart          when boardConfig.epixhrDbgSel1 = "10111" else
       dataSendStreched  when boardConfig.epixhrDbgSel1 = "11000" else
+      timingDaqTrigger  when boardConfig.epixhrDbgSel1 = "11001" else
       '0';
 
   smaTxP          <= '0';

--- a/firmware/common/ePixHrCommon/rtl/DigitalAsicStreamAxiV3.vhd
+++ b/firmware/common/ePixHrCommon/rtl/DigitalAsicStreamAxiV3.vhd
@@ -370,7 +370,14 @@ begin
       end if;
       
       case r.state is
-         when IDLE_S =>
+        when IDLE_S =>
+            -- flushes data since it should not exist in the fifo before a trigger
+            for i in 0 to (LANES_NO_G-1) loop
+               if dFifoValid(i) = '1' then
+                  v.dFifoRd(i) := '1';
+               end if;             
+            end loop;
+            
             if startRdSync = '1' then
               v.state := WAIT_SOF_S;
               -- provides a 1 clock cycle hls core reset before new frame arrives

--- a/firmware/common/ePixHrCommon/rtl/DigitalAsicStreamAxiV3.vhd
+++ b/firmware/common/ePixHrCommon/rtl/DigitalAsicStreamAxiV3.vhd
@@ -190,6 +190,7 @@ architecture RTL of DigitalAsicStreamAxiV3 is
    attribute keep of dFifoEof    : signal is "true";
    attribute keep of dFifoSof    : signal is "true";
    attribute keep of dFifoValid  : signal is "true";
+   attribute keep of dFifoRd     : signal is "true";   
    
    
    
@@ -257,7 +258,7 @@ begin
       begin
         if (GAIN_BIT_REMAP_G = true) then
           rxDataReMap(i)(13 downto 0)   <= rxData(i)(15 downto 2);
-          rxDataReMap(i)(14)            <= rxData(i)(0);
+          rxDataReMap(i)(14)            <= '0';
           rxDataReMap(i)(15)            <= rxData(i)(0);
         else
           rxDataReMap(i) <= rxData(i);

--- a/firmware/targets/EpixHr10kTLclsIITiming/vivado/debug.tcl
+++ b/firmware/targets/EpixHr10kTLclsIITiming/vivado/debug.tcl
@@ -33,7 +33,7 @@ CreateDebugCore ${ilaName}
 #######################
 ## Set the record depth
 #######################
-set_property C_DATA_DEPTH 2048 [get_debug_cores ${ilaName}]
+set_property C_DATA_DEPTH 4096 [get_debug_cores ${ilaName}]
 
 #################################
 ## Set the clock for the ILA core

--- a/firmware/targets/EpixHr10kTLclsIITiming/vivado/debug.tcl
+++ b/firmware/targets/EpixHr10kTLclsIITiming/vivado/debug.tcl
@@ -68,11 +68,21 @@ SetDebugCoreClk ${ilaName} {U_App/deserClk}
 #ConfigProbe ${ilaName} {U_App/rxData[*]}
 #ConfigProbe ${ilaName} {U_App/rxSof[*]}
 #ConfigProbe ${ilaName} {U_App/rxEofe[*]}
-ConfigProbe ${ilaName} {U_App/G_ASICS[1].U_Framers/r[txMaster][*]}
-ConfigProbe ${ilaName} {U_App/G_ASICS[1].U_Framers/r[dFifoRd][*]}
+#ConfigProbe ${ilaName} {U_App/G_ASICS[1].U_Framers/r[txMaster][*]}
+ConfigProbe ${ilaName} {U_App/G_ASICS[0].U_Framers/startRdSync}
+ConfigProbe ${ilaName} {U_App/G_ASICS[0].U_Framers/dFifoRd[*]}
+ConfigProbe ${ilaName} {U_App/G_ASICS[0].U_Framers/dFifoEof[*]}
+ConfigProbe ${ilaName} {U_App/G_ASICS[0].U_Framers/dFifoSof[*]}
+ConfigProbe ${ilaName} {U_App/G_ASICS[0].U_Framers/r[state][*]}
+ConfigProbe ${ilaName} {U_App/G_ASICS[0].U_Framers/dFifoValid[*]}
+#
+ConfigProbe ${ilaName} {U_App/G_ASICS[1].U_Framers/startRdSync}
+ConfigProbe ${ilaName} {U_App/G_ASICS[1].U_Framers/dFifoRd[*]}
+ConfigProbe ${ilaName} {U_App/G_ASICS[1].U_Framers/dFifoEof[*]}
+ConfigProbe ${ilaName} {U_App/G_ASICS[1].U_Framers/dFifoSof[*]}
 ConfigProbe ${ilaName} {U_App/G_ASICS[1].U_Framers/r[state][*]}
 ConfigProbe ${ilaName} {U_App/G_ASICS[1].U_Framers/dFifoValid[*]}
-ConfigProbe ${ilaName} {U_App/G_ASICS[1].U_Framers/hlsTxMaster[*]}
+#ConfigProbe ${ilaName} {U_App/G_ASICS[1].U_Framers/hlsTxMaster[*]}
 #ConfigProbe ${ilaName} {U_App/G_ASICS[0].U_Framers/sAxisMaster[*]}
 #ConfigProbe ${ilaName} {U_App/G_ASICS[0].U_Framers/imAxisMaster[*]}
 #ConfigProbe ${ilaName} {U_App/G_ASICS[0].U_Framers/imAxisSlave[*]}

--- a/software/python/ePixFpga/_ePixFpga.py
+++ b/software/python/ePixFpga/_ePixFpga.py
@@ -1035,7 +1035,7 @@ class EPixHr10kTAppCoreRegLCLS(pr.Device):
       #############################################
       # Create block / variable combinations
       #############################################
-      debugChEnum={0:'Asic01DM', 1:'AsicSync', 2:'AsicAcq', 3:'AsicSR0', 4:'AsicSaciClk', 5:'AsicSaciCmd', 6:'AsicSaciResp', 7:'AsicSaciSelL(0)', 8:'AsicSaciSelL(1)', 9:'AsicRdClk', 10:'deserClk', 11:'WFdacDin', 12:'WFdacSclk', 13:'WFdacCsL', 14:'WFdacLdacL', 15: 'WFdacCrtlL', 16: 'AsicGRst', 17: 'AsicR0', 18: 'SlowAdcDin', 19: 'SlowAdcDrdy', 20: 'SlowAdcDout', 21: 'slowAdcRefClk', 22: 'pgpTrigger', 23: 'acqStart'}
+      debugChEnum={0:'Asic01DM', 1:'AsicSync', 2:'AsicAcq', 3:'AsicSR0', 4:'AsicSaciClk', 5:'AsicSaciCmd', 6:'AsicSaciResp', 7:'AsicSaciSelL(0)', 8:'AsicSaciSelL(1)', 9:'AsicRdClk', 10:'deserClk', 11:'WFdacDin', 12:'WFdacSclk', 13:'WFdacCsL', 14:'WFdacLdacL', 15: 'WFdacCrtlL', 16: 'AsicGRst', 17: 'AsicR0', 18: 'SlowAdcDin', 19: 'SlowAdcDrdy', 20: 'SlowAdcDout', 21: 'slowAdcRefClk', 22: 'pgpTrigger', 23: 'acqStart', 24: 'dataSend', 25: 'timingRun@tg_Daq@MPS_Trigger'}
 
       #Setup registers & variables
       


### PR DESCRIPTION
Merging fixes to the Digital readout mechanism to clear the FIFOs while receiving more run triggers than daq triggers. Also set bit 14 to be always zero as requested by LCLS data systems.